### PR TITLE
Add a rust linter and formatter (Take 2)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_precommit:
+  run:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run_precommit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit-ci/lite-action@v1.0.2
+      if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,15 @@ repos:
   - repo: https://github.com/psf/black
     rev: 24.4.0
     hooks:
-        - id: black
+      - id: black
+  # Rust code formatting
+  - repo: https://github.com/FeryET/pre-commit-rust
+    rev: v1.1.0
+    hooks:
+      # - id: fmt
+      - id: cargo-check
+      - id: clippy
+        args: ["--", "-A", "clippy::needless_return"]
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,9 +46,9 @@ repos:
     rev: v1.1.0
     hooks:
       - id: cargo-check
-      - id: fmt
       - id: clippy
         args: ["--allow-staged", "--fix", "--", "-A", "clippy::needless_return"]
+      - id: fmt
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,10 +45,10 @@ repos:
   - repo: https://github.com/FeryET/pre-commit-rust
     rev: v1.1.0
     hooks:
-      # - id: fmt
       - id: cargo-check
-      - id: clippy
-        args: ["--", "-A", "clippy::needless_return"]
+      - id: fmt
+      # - id: clippy
+      #   args: ["--", "-A", "clippy::needless_return"]
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: cargo-check
       - id: clippy
-        args: ["--allow-staged", "--fix", "--", "-A", "clippy::needless_return"]
+        args: ["--allow-staged", "--fix", "--", "-A", "clippy::needless_return", "-W", "clippy::implicit_return"]
       - id: fmt
 ci:
   autofix_prs: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,8 +47,8 @@ repos:
     hooks:
       - id: cargo-check
       - id: fmt
-      # - id: clippy
-      #   args: ["--", "-A", "clippy::needless_return"]
+      - id: clippy
+        args: ["--allow-staged", "--fix", "--", "-A", "clippy::needless_return"]
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ name = "streamtracer"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = {version = "0.20", features = ["extension-module"]}
-numpy = "0.20"
+pyo3 = {version = "0.21", features = ["extension-module"]}
+numpy = "0.21"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 rayon = "1.8"
 ndarray = {version = "0.15", features = ["rayon"]}
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -162,11 +162,13 @@ impl VectorField<'_> {
 
     /// Check whether a coordinate is in bounds of the grid.
     pub fn check_bounds(&self, x: ArrayView1<f64>) -> Bounds {
-        if (x[0] < self.xgrid[0]) || (x[0] > self.xgrid[self.nx - 1]) {
-            return Bounds::Out;
-        } else if x[1] < self.ygrid[0] || x[1] > self.ygrid[self.ny - 1] {
-            return Bounds::Out;
-        } else if x[2] < self.zgrid[0] || x[2] > self.zgrid[self.nz - 1] {
+        if (x[0] < self.xgrid[0])
+            || (x[0] > self.xgrid[self.nx - 1])
+            || (x[1] < self.ygrid[0])
+            || (x[1] > self.ygrid[self.ny - 1])
+            || (x[2] < self.zgrid[0])
+            || (x[2] > self.zgrid[self.nz - 1])
+        {
             return Bounds::Out;
         }
         return Bounds::In;

--- a/src/field.rs
+++ b/src/field.rs
@@ -68,7 +68,7 @@ impl VectorField<'_> {
 
         let upper_bounds = array![xgrid[nx - 1], ygrid[ny - 1], zgrid[nz - 1]];
 
-        VectorField {
+        return VectorField {
             xgrid,
             ygrid,
             zgrid,
@@ -78,7 +78,7 @@ impl VectorField<'_> {
             ny,
             nz,
             upper_bounds,
-        }
+        };
     }
 
     /// Return grid index of the cell containing `x`.

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1,7 +1,6 @@
 //! Helper functions for interpolation.
 
-use numpy::ndarray::{Array1, Array, ArrayBase, Ix3, Data};
-
+use numpy::ndarray::{Array, Array1, ArrayBase, Data, Ix3};
 
 /// Trilinear-interpolation of a scalar defined on
 /// the eight corners of a cuboid.
@@ -10,12 +9,9 @@ use numpy::ndarray::{Array1, Array, ArrayBase, Ix3, Data};
 ///
 /// * `values` - Values on the eight cube corners. Must be shape `(2, 2, 2)`.
 /// * `x` - Coordinate to interpolate at. Components must be `>= 0` and `<=1`. Must be shape `(3,)`.
-pub fn interp_trilinear<S>(
-    values: &ArrayBase<S, Ix3>,
-    x: &Array1<f64>
-) -> f64
+pub fn interp_trilinear<S>(values: &ArrayBase<S, Ix3>, x: &Array1<f64>) -> f64
 where
-    S: Data<Elem=f64>
+    S: Data<Elem = f64>,
 {
     if values.dim() != (2, 2, 2) {
         panic!("Interp values are not the right shape {:?}", values.shape());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,14 @@ use numpy::{
     ndarray::Array, IntoPyArray, PyArray1, PyArray3, PyReadonlyArray1, PyReadonlyArray2,
     PyReadonlyArray4,
 };
-use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
+use pyo3::prelude::{pymodule, Bound, PyModule, PyResult, Python};
 
 #[pymodule]
 #[pyo3(name = "_streamtracer_rust")]
-fn streamtracer(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn streamtracer(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     #[pyfn(m)]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
     fn trace_streamlines<'py>(
         py: Python<'py>,
         seeds: PyReadonlyArray2<f64>,
@@ -32,7 +33,11 @@ fn streamtracer(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
         direction: i32,
         step_size: f64,
         max_steps: usize,
-    ) -> (&'py PyArray3<f64>, &'py PyArray1<i64>, &'py PyArray1<i64>) {
+    ) -> (
+        Bound<'py, PyArray3<f64>>,
+        Bound<'py, PyArray1<i64>>,
+        Bound<'py, PyArray1<i64>>,
+    ) {
         let (statuses, xs) = trace::trace_streamlines(
             seeds.as_array(),
             xgrid.as_array(),
@@ -53,9 +58,9 @@ fn streamtracer(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
         }
 
         return (
-            xs.into_pyarray(py),
-            n_points.into_pyarray(py),
-            termination_reasons.into_pyarray(py),
+            xs.into_pyarray_bound(py),
+            n_points.into_pyarray_bound(py),
+            termination_reasons.into_pyarray_bound(py),
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,5 +64,5 @@ fn streamtracer(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         );
     }
 
-    Ok(())
+    return Ok(());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
 #[pyo3(name = "_streamtracer_rust")]
 fn streamtracer(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     #[pyfn(m)]
+    #[allow(clippy::too_many_arguments)]
     fn trace_streamlines<'py>(
         py: Python<'py>,
         seeds: PyReadonlyArray2<f64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,11 @@ mod test_field;
 mod test_interp;
 mod test_tracer;
 
-use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyReadonlyArray4, PyArray1, PyArray3, IntoPyArray, ndarray::Array};
+use numpy::{
+    ndarray::Array, IntoPyArray, PyArray1, PyArray3, PyReadonlyArray1, PyReadonlyArray2,
+    PyReadonlyArray4,
+};
 use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
-
 
 #[pymodule]
 #[pyo3(name = "_streamtracer_rust")]
@@ -39,7 +41,7 @@ fn streamtracer(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
             cyclic.as_array(),
             direction,
             step_size,
-            max_steps
+            max_steps,
         );
 
         let mut termination_reasons = Array::zeros(statuses.len());
@@ -49,7 +51,11 @@ fn streamtracer(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
             n_points[[i]] = status.n_points as i64;
         }
 
-        return (xs.into_pyarray(py), n_points.into_pyarray(py), termination_reasons.into_pyarray(py))
+        return (
+            xs.into_pyarray(py),
+            n_points.into_pyarray(py),
+            termination_reasons.into_pyarray(py),
+        );
     }
 
     Ok(())

--- a/src/test_field.rs
+++ b/src/test_field.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
-mod field_tests{
-    use numpy::ndarray::{array, Array, Array4, s};
+mod field_tests {
     use float_eq::assert_float_eq;
+    use numpy::ndarray::{array, s, Array, Array4};
 
     use super::super::field::VectorField;
 
@@ -13,7 +13,13 @@ mod field_tests{
         let mut field: Array4<f64> = Array::zeros((3, 4, 5, 3));
         field.slice_mut(s![2, 2.., 2.., 0]).fill(1.);
         let cyclic = array![true, false, true];
-        let f = VectorField::new(xgrid.view(), ygrid.view(), zgrid.view(), field.view(), cyclic.view());
+        let f = VectorField::new(
+            xgrid.view(),
+            ygrid.view(),
+            zgrid.view(),
+            field.view(),
+            cyclic.view(),
+        );
 
         let x = array![0.15, 1.05, 0.05];
         assert_eq!(f.grid_idx(x.view()), array![0, 0, 0]);
@@ -33,7 +39,13 @@ mod field_tests{
         let mut field: Array4<f64> = Array::zeros((3, 4, 5, 3));
         field.slice_mut(s![2, 2.., 2.., 0]).fill(1.);
         let cyclic = array![true, false, true];
-        let f = VectorField::new(xgrid.view(), ygrid.view(), zgrid.view(), field.view(), cyclic.view());
+        let f = VectorField::new(
+            xgrid.view(),
+            ygrid.view(),
+            zgrid.view(),
+            field.view(),
+            cyclic.view(),
+        );
 
         let mut x = array![0.15, 1.05, 0.05];
 
@@ -47,7 +59,7 @@ mod field_tests{
         x = array![0.275, 1.2, 50.0];
         let vec = f.vector_at_position(x.view());
         let expected = array![0.75, 0., 0.];
-        for i in 0..2{
+        for i in 0..2 {
             assert_float_eq!(vec[i], expected[i], abs <= 0.000_000_1);
         }
     }

--- a/src/test_interp.rs
+++ b/src/test_interp.rs
@@ -1,12 +1,11 @@
 #[cfg(test)]
-mod interp_tests{
+mod interp_tests {
     use super::super::interp;
     use numpy::ndarray::array;
 
     #[test]
     fn test_interp_trilin() {
-        let values = array![[[0., 1.], [0., 1.]],
-                            [[0., 1.], [0., 1.]]];
+        let values = array![[[0., 1.], [0., 1.]], [[0., 1.], [0., 1.]]];
         let a = array![0.3, 0.2, 0.4];
         let b = interp::interp_trilinear(&values, &a);
         assert_eq!(b, 0.4);

--- a/src/test_tracer.rs
+++ b/src/test_tracer.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
-mod tests{
-    use numpy::ndarray::{array, Array, s};
+mod tests {
+    use numpy::ndarray::{array, s, Array};
 
     use super::super::field::VectorField;
-    use super::super::trace::{TracerStatus, trace_streamline};
+    use super::super::trace::{trace_streamline, TracerStatus};
 
     #[test]
     fn test_uniform_field() {
@@ -15,7 +15,13 @@ mod tests{
         field.slice_mut(s![.., .., .., 0]).fill(1.);
 
         let cyclic = array![false, false, false];
-        let f = VectorField::new(xgrid.view(), ygrid.view(), zgrid.view(), field.view(), cyclic.view());
+        let f = VectorField::new(
+            xgrid.view(),
+            ygrid.view(),
+            zgrid.view(),
+            field.view(),
+            cyclic.view(),
+        );
 
         let seed = array![5., 5., 5.];
         let direction = 1;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -46,6 +46,7 @@ pub struct StreamlineResult {
 /// * `step_size` - Size of each individual step to take.
 /// * `max_steps` - Maximum number of steps to take per streamline.
 ///   This directly sets the size of the output streamline array.
+#[allow(clippy::too_many_arguments)]
 pub fn trace_streamlines<'a>(
     seeds: ArrayView2<'a, f64>,
     xgrid: ArrayView1<'a, f64>,

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -66,12 +66,14 @@ pub fn trace_streamlines<'a>(
         .into_par_iter()
         .map(|seed| {
             let result = trace_streamline(seed, &field, &direction, &step_size, max_steps);
-            (result.status, result.line)
+            return (result.status, result.line);
         })
         .unzip();
 
-    let extracted_lines_views: Vec<ArrayView2<f64>> =
-        extracted_lines.iter().map(|arr| arr.view()).collect();
+    let extracted_lines_views: Vec<ArrayView2<f64>> = extracted_lines
+        .iter()
+        .map(|arr| return arr.view())
+        .collect();
     let xs = stack(Axis(0), &extracted_lines_views).unwrap();
     return (statuses, xs);
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,12 +1,14 @@
 //! Streamline tracing functionality.
-use num_derive::ToPrimitive;
-use numpy::ndarray::{Array, Array1, Array2, Array3, ArrayView1, ArrayView2, ArrayView4, Axis, stack};
 use ndarray::parallel::prelude::*;
+use num_derive::ToPrimitive;
+use numpy::ndarray::{
+    stack, Array, Array1, Array2, Array3, ArrayView1, ArrayView2, ArrayView4, Axis,
+};
 
-use crate::field::{VectorField, Bounds};
+use crate::field::{Bounds, VectorField};
 /// Enum denoting status of the streamline tracer
 #[derive(PartialEq, Debug, ToPrimitive, Clone, Copy)]
-pub enum TracerStatus{
+pub enum TracerStatus {
     /// Still running
     Running,
     /// Ran out of steps
@@ -17,17 +19,17 @@ pub enum TracerStatus{
 
 /// A single stream line status
 #[derive(Clone)]
-pub struct StreamlineStatus{
+pub struct StreamlineStatus {
     /// Reason of termination
     pub rot: TracerStatus,
     /// Number of valid coordinates returned
     /// Can be used to slice away extra bits of the array that were not
     /// used for tracing using `xs.slice(s![:n_points, ..])`.
-    pub n_points: usize
+    pub n_points: usize,
 }
 
 /// A result of tracing a streamline
-pub struct StreamlineResult{
+pub struct StreamlineResult {
     /// The status of a trace
     pub status: StreamlineStatus,
     /// The array of line coordinates that were traced
@@ -54,7 +56,7 @@ pub fn trace_streamlines<'a>(
     direction: i32,
     step_size: f64,
     max_steps: usize,
-) ->  (Vec<StreamlineStatus>, Array3<f64>) {
+) -> (Vec<StreamlineStatus>, Array3<f64>) {
     let field = VectorField::new(xgrid, ygrid, zgrid, values, cyclic);
 
     // Trace from each seed in turn
@@ -62,17 +64,13 @@ pub fn trace_streamlines<'a>(
         .axis_iter(Axis(0))
         .into_par_iter()
         .map(|seed| {
-             let result = trace_streamline(
-                seed,
-                &field,
-                &direction,
-                &step_size,
-                max_steps,
-            );
+            let result = trace_streamline(seed, &field, &direction, &step_size, max_steps);
             (result.status, result.line)
-        }).unzip();
+        })
+        .unzip();
 
-    let extracted_lines_views: Vec<ArrayView2<f64>> = extracted_lines.iter().map(|arr| arr.view()).collect();
+    let extracted_lines_views: Vec<ArrayView2<f64>> =
+        extracted_lines.iter().map(|arr| arr.view()).collect();
     let xs = stack(Axis(0), &extracted_lines_views).unwrap();
     return (statuses, xs);
 }
@@ -107,19 +105,19 @@ pub fn trace_streamline(
     x.assign(&x0);
 
     // Take streamline steps
-    for i in 0..max_steps{
+    for i in 0..max_steps {
         // Copy current coordinate
         for j in 0..3 {
             xs[[i, j]] = x[[j]];
         }
         // +1 to account for the initial point
-        n_points = i+1;
+        n_points = i + 1;
         // Take a single step
         // Updates `x` in place.
         x = rk4_update(x, field, &step);
         x = field.wrap_cyclic(x);
         // Check new point isn't out of bounds
-        match field.check_bounds(x.view()){
+        match field.check_bounds(x.view()) {
             Bounds::Out => {
                 status = TracerStatus::OutOfBounds;
                 break;
@@ -135,21 +133,17 @@ pub fn trace_streamline(
         status = TracerStatus::RanOutOfSteps;
     }
 
-    return StreamlineResult{
-        status: StreamlineStatus{
+    return StreamlineResult {
+        status: StreamlineStatus {
             rot: status,
-            n_points
+            n_points,
         },
         line: xs,
-    }
+    };
 }
 
 // Update a coordinate (`x`) by taking a single RK4 step
-fn rk4_update(
-    mut x: Array1<f64>,
-    field: &VectorField,
-    step_size: &f64
-) -> Array1<f64> {
+fn rk4_update(mut x: Array1<f64>, field: &VectorField, step_size: &f64) -> Array1<f64> {
     let mut xu = x.clone();
     let k1 = stream_function(xu.view(), field, step_size);
 
@@ -169,16 +163,8 @@ fn rk4_update(
 
 /// Return the step that a linear tracing method would take
 /// at a given position.
-fn stream_function(
-    x: ArrayView1<f64>,
-    field: &VectorField,
-    step_size: &f64
-) -> Array1<f64> {
+fn stream_function(x: ArrayView1<f64>, field: &VectorField, step_size: &f64) -> Array1<f64> {
     let vec = field.vector_at_position(x);
-    let vmag = (
-        vec[[0]].powf(2.) +
-        vec[[1]].powf(2.) +
-        vec[[2]].powf(2.)
-    ).sqrt();
+    let vmag = (vec[[0]].powf(2.) + vec[[1]].powf(2.) + vec[[2]].powf(2.)).sqrt();
     return (*step_size) * vec / vmag;
 }


### PR DESCRIPTION
This adds some rust specific pre-commit hooks as recommended by @Will-Shanks in #110 

It seems that these checks don't play nice with pre-commit.ci so I have swapped to using pre-commit.ci lite and GH actions to run them, which means enabling autofix.

Oh, also somewhat controversially I have configured clippy to enforce the presence of return statements, as I think that will be better for people likely to contribute here who are more familiar with Python.