### PR TITLE
Minor docstring formatting fixes, refactor input argument validation, and fix bug when tracing in +/-1 direction

### DIFF
--- a/python/streamtracer/streamline.py
+++ b/python/streamtracer/streamline.py
@@ -103,7 +103,8 @@ class VectorGrid:
                 shape = np.array(val[i]).shape
                 if shape != (self.vectors.shape[i],):
                     raise ValueError(
-                        f"Expected {self.vectors.shape[i]} {dim} " f"coordinates but got {shape}"
+                        f"Expected {self.vectors.shape[i]} {dim} "
+                        f"coordinates but got {shape}"
                     )
         self._coords = val
 
@@ -143,7 +144,9 @@ class VectorGrid:
             if self.grid_spacing is not None:
                 self._origin_coord = np.array([0, 0, 0])
             else:
-                self._origin_coord = np.array([self.xcoords[0], self.ycoords[0], self.zcoords[0]])
+                self._origin_coord = np.array(
+                    [self.xcoords[0], self.ycoords[0], self.zcoords[0]]
+                )
         else:
             self._origin_coord = np.array(val)
 

--- a/python/streamtracer/streamline.py
+++ b/python/streamtracer/streamline.py
@@ -305,7 +305,7 @@ class StreamTracer:
 
             self.xs += grid.origin_coord
             # Reduce the size of the arrays
-            self.xs = np.array([xi[:ni, :] for xi, ni in zip(self.xs, self.ns)])
+            self.xs = [xi[:ni, :] for xi, ni in zip(self.xs, self.ns)]
 
         elif direction == 0:
             # Calculate forward streamline

--- a/python/streamtracer/streamline.py
+++ b/python/streamtracer/streamline.py
@@ -64,7 +64,9 @@ class VectorGrid:
 
     @property
     def grid_spacing(self):
-        "Physical spacing between grid points along each axis."
+        """
+        Physical spacing between grid points along each axis.
+        """
         return self._grid_spacing
 
     @grid_spacing.setter
@@ -79,7 +81,9 @@ class VectorGrid:
 
     @property
     def vectors(self):
-        "Three-dimensional vector field through which the streamlines will be traced."
+        """
+        Three-dimensional vector field through which the streamlines will be traced.
+        """
         return self._vectors
 
     @vectors.setter
@@ -94,7 +98,9 @@ class VectorGrid:
 
     @property
     def coords(self):
-        "The physical coordinates along each axis of the grid."
+        """
+        The physical coordinates along each axis of the grid.
+        """
         return self._coords
 
     @coords.setter

--- a/python/streamtracer/streamline.py
+++ b/python/streamtracer/streamline.py
@@ -172,21 +172,21 @@ class VectorGrid:
     @property
     def xcoords(self):
         """
-        Coordinates of the x grid points.
+        Physical coordinates corresponding to grid points in the x-direction.
         """
         return self._get_coords(0)
 
     @property
     def ycoords(self):
         """
-        Coordinates of the y grid points.
+        Physical coordinates corresponding to grid points in the y-direction.
         """
         return self._get_coords(1)
 
     @property
     def zcoords(self):
         """
-        Coordinates of the z grid points.
+        Physical coordinates corresponding to grid points in the z-direction.
         """
         return self._get_coords(2)
 
@@ -212,8 +212,11 @@ class StreamTracer:
     @property
     def xs(self):
         """
-        An array of the streamlines each with shape ``(n,3)``, which in general can have varying
-        numbers of points.
+        List of the coordinates along each streamline.
+
+        List of three-dimensional coordinates for each streamline.
+        Each strealine coordinate has a shape ``(n,3)``, where ``n`` can, in principle, vary
+        from one streamline to the next.
         """
         return self._xs
 

--- a/python/streamtracer/streamline.py
+++ b/python/streamtracer/streamline.py
@@ -17,10 +17,10 @@ class VectorGrid:
 
     Parameters
     ----------
-    vectors : array
+    vectors : array-like
         A (nx, ny, nz, 3) shaped array. The three values at (i, j, k, :)
         specify the (x, y, z) components of the vector at index (i, j, k).
-    grid_spacing : array, optional
+    grid_spacing : array-like, optional
         A (3,) shaped array, that contains the grid spacings in the (x, y, z)
         directions. If not specified ``grid_coords`` must be specified.
     origin_coord : [`float`, `float`, `float`], optional
@@ -64,6 +64,7 @@ class VectorGrid:
 
     @property
     def grid_spacing(self):
+        "Physical spacing between grid points along each axis."
         return self._grid_spacing
 
     @grid_spacing.setter
@@ -78,6 +79,7 @@ class VectorGrid:
 
     @property
     def vectors(self):
+        "Three-dimensional vector field through which the streamlines will be traced."
         return self._vectors
 
     @vectors.setter
@@ -92,6 +94,7 @@ class VectorGrid:
 
     @property
     def coords(self):
+        "The physical coordinates along each axis of the grid."
         return self._coords
 
     @coords.setter
@@ -110,6 +113,10 @@ class VectorGrid:
 
     @property
     def cyclic(self):
+        """
+        Boolean describing whether to have cyclic boundary conditions in each of the (x, y, z)
+        directions.
+        """
         return self._cyclic
 
     @cyclic.setter
@@ -136,6 +143,9 @@ class VectorGrid:
 
     @property
     def origin_coord(self):
+        """
+        The physical coordinate corresponding to the index at ``(0,0,0)``.
+        """
         return self._origin_coord
 
     @origin_coord.setter
@@ -169,14 +179,14 @@ class VectorGrid:
     @property
     def ycoords(self):
         """
-        Coordinates of the x grid points.
+        Coordinates of the y grid points.
         """
         return self._get_coords(1)
 
     @property
     def zcoords(self):
         """
-        Coordinates of the x grid points.
+        Coordinates of the z grid points.
         """
         return self._get_coords(2)
 
@@ -249,7 +259,6 @@ class StreamTracer:
 
         self._max_steps = val
 
-    # Calculate the streamline from a vector array
     def trace(self, seeds, grid, direction=0):
         """
         Trace streamlines.


### PR DESCRIPTION
This PR does ~~two~~ three things:

- Fix some of the formatting in the docstrings for `VectorGrid` and `Streamtracer`. Also moved `xs` and `ROT` to be properties so that their attribute docstrings render more nicely.
- Refactor the input validation on `VectorGrid`. Previously, the validation was done using a mix of some setters and some static validation methods. This refactor moves all of the validation to setter methods.
- Fixes a bug in `Streamtracer.trace()` in the `direction=+/-1` cases where the streamlines were trying to be returned as an array, but were failing because each array within that array was of unequal length. This returns them as a list, consistent with the `direction=0` case. Maybe this needs a test? If it was already covered, I'm not sure how it was passing previously. I could move this to a separate PR if that is preferable. 